### PR TITLE
#5 Added fagblogg teaser block

### DIFF
--- a/miles-wp-web-components-plugin.php
+++ b/miles-wp-web-components-plugin.php
@@ -29,6 +29,7 @@ function create_block_miles_editor_blocks_block_init(): void {
 	register_block_type( __DIR__ . '/build/miles-contact-card' );
 	register_block_type( __DIR__ . '/build/miles-image-block' );
 	register_block_type( __DIR__ . '/build/miles-office-banner' );
+	register_block_type( __DIR__ . '/build/miles-fagblogg-teaser' );
 
 }
 

--- a/miles-wp-web-components-plugin.php
+++ b/miles-wp-web-components-plugin.php
@@ -77,26 +77,6 @@ function miles_wrap_gallery( $block_content, $block ) {
 	}
 }
 
-
-add_filter( 'render_block', 'miles_fagblogg_teaser', 10, 3 );
-
-function miles_fagblogg_teaser( $block_content, $block ) {
-
-	if ( "core/latest-posts" !== $block['blockName'] ) {
-		return $block_content;
-	}
-
-	if ( str_contains( $block['attrs']['className'], 'miles-fagblogg-teaser' ) ) {
-		$output = '<miles-fagblogg-teaser>';
-		$output .= $block_content;
-		$output .= '</miles-fagblogg-teaser>';
-
-		return $output;
-	} else {
-		return $block_content;
-	}
-}
-
 add_filter( 'render_block', 'miles_overlap_block', 10, 3 );
 
 function miles_overlap_block( $block_content, $block ) {

--- a/src/miles-fagblogg-teaser/block.json
+++ b/src/miles-fagblogg-teaser/block.json
@@ -1,0 +1,39 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "miles-blocks/miles-fagblogg-teaser",
+	"version": "0.1.0",
+	"title": "Miles Fagblogg Teaser Block",
+	"category": "widgets",
+	"icon": "index-card",
+	"description": "Fagblogg teaser block",
+	"supports": {
+		"html": false
+	},
+	"attributes": {
+		"link" : {
+			"type": "string",
+            "default": "http://www.miles.no/milespodden"
+		},
+        "numberOfPosts": {
+            "type": "number",
+            "default": 3
+        },
+        "displayPostDate": {
+            "type": "boolean",
+            "default": true
+        },
+        "displayAuthor": {
+            "type": "boolean",
+            "default": true
+        },
+        "displayFeaturedImage": {
+            "type": "boolean",
+            "default": true
+        }
+	},
+	"textdomain": "miles-fagblogg-teaser",
+	"editorScript": "file:./index.js",
+	"editorStyle": "file:./index.css",
+	"render": "file:./render.php"
+}

--- a/src/miles-fagblogg-teaser/edit.js
+++ b/src/miles-fagblogg-teaser/edit.js
@@ -1,0 +1,101 @@
+/**
+ * Retrieves the translation of text.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-i18n/
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * React hook that is used to mark the block wrapper element.
+ * It provides all the necessary props like the class name.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-block-editor/#useblockprops
+ */
+import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
+import ServerSideRender from '@wordpress/server-side-render';
+import { Panel, PanelBody, PanelRow, TextControl } from '@wordpress/components';
+
+/**
+ * Lets webpack process CSS, SASS or SCSS files referenced in JavaScript files.
+ * Those files can contain any CSS code that gets applied to the editor.
+ *
+ * @see https://www.npmjs.com/package/@wordpress/scripts#using-css
+ */
+import './editor.scss';
+import blockInfo from './block.json';
+/**
+ * The edit function describes the structure of your block in the context of the
+ * editor. This represents what the editor will render when the block is used.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#edit
+ *
+ * @return {WPElement} Element to render.
+ */
+export default function Edit({ attributes, setAttributes }) {
+
+	function changeLink(changedLink) {
+		setAttributes({ link: changedLink });
+	}
+
+	function changeNumberOfPosts(changedNumberOfPosts) {
+		setAttributes({ numberOfPosts: parseInt(changedNumberOfPosts, 10) });
+	}
+
+	function toggleDisplayAuthor(checked) {
+		setAttributes({ displayAuthor: checked });
+	}
+	function toggleDisplayPostDate(checked) {
+		setAttributes({ displayPostDate: checked });
+	}
+	function toggleDisplayFeaturedImage(checked) {
+		setAttributes({ displayFeaturedImage: checked });
+	}
+
+	return (
+		<section {...useBlockProps()}>
+			<InspectorControls>
+				<Panel header={__('Miles Fagblogg Teaser Settings', 'miles-fagblogg-teaser')}>
+					<PanelBody title={__('Miles Fagblogg Teaser Settings', 'miles-fagblogg-teaser')}>
+						<PanelRow>
+							<TextControl
+								label={__('Link', 'miles-fagblogg-teaser')}
+								onChange={changeLink}
+								value={attributes.link}
+							/>
+						</PanelRow>
+						<PanelRow>
+							<TextControl
+								label={__('Number of Posts', 'miles-fagblogg-teaser')}
+								onChange={changeNumberOfPosts}
+								value={attributes.numberOfPosts}
+								type="number"
+							/>
+						</PanelRow>
+						<PanelRow>
+						<ToggleControl
+								label="Display Author"
+								checked={attributes.displayAuthor}
+								onChange={toggleDisplayAuthor}
+							/>
+						</PanelRow>
+						<PanelRow>
+						<ToggleControl
+								label="Display Post Date"
+								checked={attributes.displayPostDate}
+								onChange={toggleDisplayPostDate}
+							/>
+						</PanelRow>
+						<PanelRow>
+							<ToggleControl
+								label="Display Image"
+								checked={attributes.displayFeaturedImage}
+								onChange={toggleDisplayFeaturedImage}
+							/>
+						</PanelRow>
+					</PanelBody>
+				</Panel>
+			</InspectorControls>
+			<ServerSideRender skipBlockSupportAttributes block={blockInfo.name} attributes={attributes} />
+		</section>
+	);
+}

--- a/src/miles-fagblogg-teaser/editor.scss
+++ b/src/miles-fagblogg-teaser/editor.scss
@@ -1,0 +1,11 @@
+/**
+ * The following styles get applied inside the editor only.
+ *
+ * Replace them with your own styles or remove the file completely.
+ */
+
+ #fagblogg-teaser {
+	width: 100%;
+	position: relative;
+	margin: auto;
+ }

--- a/src/miles-fagblogg-teaser/index.js
+++ b/src/miles-fagblogg-teaser/index.js
@@ -6,15 +6,6 @@
 import { registerBlockType } from '@wordpress/blocks';
 
 /**
- * Lets webpack process CSS, SASS or SCSS files referenced in JavaScript files.
- * All files containing `style` keyword are bundled together. The code used
- * gets applied both to the front of your site and to the editor.
- *
- * @see https://www.npmjs.com/package/@wordpress/scripts#using-css
- */
-import './style.scss';
-
-/**
  * Internal dependencies
  */
 import Edit from './edit';

--- a/src/miles-fagblogg-teaser/index.js
+++ b/src/miles-fagblogg-teaser/index.js
@@ -1,0 +1,33 @@
+/**
+ * Registers a new block provided a unique name and an object defining its behavior.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/
+ */
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Lets webpack process CSS, SASS or SCSS files referenced in JavaScript files.
+ * All files containing `style` keyword are bundled together. The code used
+ * gets applied both to the front of your site and to the editor.
+ *
+ * @see https://www.npmjs.com/package/@wordpress/scripts#using-css
+ */
+import './style.scss';
+
+/**
+ * Internal dependencies
+ */
+import Edit from './edit';
+import metadata from './block.json';
+
+/**
+ * Every block starts by registering a new block type definition.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/
+ */
+registerBlockType( metadata.name, {
+	/**
+	 * @see ./edit.js
+	 */
+	edit: Edit,
+} );

--- a/src/miles-fagblogg-teaser/render.php
+++ b/src/miles-fagblogg-teaser/render.php
@@ -1,0 +1,22 @@
+
+<?php
+
+    $attributestring = '';
+
+    foreach ($attributes as $key => $value) {
+        $attributestring .= $key . '="' . esc_attr($value) . '" ';
+    }
+
+    // latest post block
+    $numberOfPosts = isset($attributes['numberOfPosts']) ? intval($attributes['numberOfPosts']) : 3;
+    
+	$latestPostsBlock = '<!-- wp:latest-posts {"postsToShow":' . $numberOfPosts . ', "displayAuthor":' . ($attributes['displayAuthor'] ? 'true' : 'false') . ', "displayPostDate":' . ($attributes['displayPostDate'] ? 'true' : 'false') . ', "displayFeaturedImage":' . ($attributes['displayFeaturedImage'] ? 'true' : 'false') . '} /-->';
+
+    $parsedPosts = do_blocks($latestPostsBlock);
+
+    $output = '<miles-fagblogg-teaser ' . $attributestring . '>';
+    $output .= $parsedPosts;
+    $output .= '</miles-fagblogg-teaser>';
+
+    echo $output;
+


### PR DESCRIPTION
This PR adds a custom block for the "Fagblokk teaser" to the Wordpress editor. This gives us the following advantages:

- Preview in the editor
-  Adjust number of posts to show (defaults to 3)
- Toggles for "author", "post date" and "image". 

I have also removed the filter that we use to "hook" into the **latest-posts** block in order to embed the fagblokk teaser. 

Previous usage:

```html
<!-- wp:latest-posts {"postsToShow":3,"displayAuthor":true,"displayPostDate":true,"displayFeaturedImage":true,"featuredImageAlign":"center","featuredImageSizeWidth":260,"featuredImageSizeHeight":260,"className":"miles-fagblogg-teaser"} /-->
```

New usage:

```html
<!-- wp:miles-blocks/miles-fagblogg-teaser {"link":"http://www.miles.no/milesfpodden","numberOfPosts":6,"displayPostDate":false,"displayAuthor":false,"displayFeaturedImage":false} /-->
```

If we omit the attributes, it defaults to the following:

```javascript
link: http://www.miles.no/milesfpodden
numberOfPosts: 3
displayPostDate: true
displayAuthor: true
displayFeaturedImage: true
```

<img width="305" alt="image" src="https://github.com/miles-no/miles-wp-web-components-plugin/assets/143096204/e8d0b86b-a667-417c-b581-ba8a9bd3bfb1">


